### PR TITLE
feat: use Go module data as a version source

### DIFF
--- a/promote.go
+++ b/promote.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"time"
@@ -43,11 +44,24 @@ const (
 	remoteRepository = "https://github.com/elastic/package-storage"
 )
 
-// Build-time parameters.
+// Build info.
 var (
 	version string
 	commit  string
 )
+
+func init() {
+	if version == "" && commit == "" {
+		// Fall back to Go module data when no built with goreleaser.
+		if info, ok := debug.ReadBuildInfo(); ok {
+			if info.Main.Sum == "" {
+				info.Main.Sum = "unknown"
+			}
+			version = info.Main.Version
+			commit = info.Main.Sum
+		}
+	}
+}
 
 // Parameters
 var (

--- a/promote.go
+++ b/promote.go
@@ -52,7 +52,7 @@ var (
 
 func init() {
 	if version == "" && commit == "" {
-		// Fall back to Go module data when no built with goreleaser.
+		// Fall back to Go module data when not built with goreleaser.
 		if info, ok := debug.ReadBuildInfo(); ok {
 			if info.Main.Sum == "" {
 				info.Main.Sum = "unknown"


### PR DESCRIPTION
Fall-back to Go module data to get version and commit (Go module sum) info
when the binary is not built with goreleaser which injects the data at build-time.