### PR TITLE
feat: execute template when no changes are found

### DIFF
--- a/promote.go
+++ b/promote.go
@@ -466,7 +466,6 @@ func run() error {
 
 	if len(packages) == 0 {
 		log.Printf("No matching packages found on <%v>.", originBranch)
-		return nil
 	} else {
 		log.Printf("Found %d matching packages on <%v>.", len(packages), originBranch)
 	}

--- a/template_test.go
+++ b/template_test.go
@@ -108,6 +108,12 @@ func TestTemplateSummaryOfChanges(t *testing.T) {
 			},
 		},
 	})
+
+	testTemplate(t, "no_pending_changes.md", &SummaryOfChanges{
+		OriginBranch: originBranch,
+		TargetBranch: targetBranch,
+		Packages:     nil,
+	})
 }
 
 func testTemplate(t *testing.T, templateName string, soc *SummaryOfChanges) {

--- a/templates/summary_of_changes.md.gohtml
+++ b/templates/summary_of_changes.md.gohtml
@@ -16,6 +16,9 @@ Filtering parameters:
 {{ end }}
   - Include Deprecated: {{ .IncludeDeprecated }}
 
+{{ if not .Packages -}}
+There are no pending changes.
+{{ else }}
 {{ range $package := .Packages }}
 ### {{ $package.Title }} - {{ $package.Version }}
 Owner: {{ $package.Owner.Github }}
@@ -35,3 +38,4 @@ New Package
 To promote these packages use this command:
 
 `{{ makePromoteCommand .OriginBranch.Name .TargetBranch.Name .Packages }}`
+{{- end }}

--- a/testdata/golden/new_package.md
+++ b/testdata/golden/new_package.md
@@ -15,6 +15,7 @@ Filtering parameters:
   - Include Deprecated: false
 
 
+
 ### Vaporware - 1.0.0
 Owner: elastic/foo-team
 

--- a/testdata/golden/no_pending_changes.md
+++ b/testdata/golden/no_pending_changes.md
@@ -14,23 +14,5 @@ Filtering parameters:
 
   - Include Deprecated: false
 
+There are no pending changes.
 
-
-### AWS - 1.8.0
-Owner: elastic/foo-team
-
-Requires: ^8.0.0
-
-Changes since 1.7.0
-
-  - 1.8.0
-     - enhancement: Update ECS ([PR](https://github.com/elastic/integrations/pull/123))
-     - bugfix: Fix bug ([PR](https://github.com/elastic/integrations/pull/124))
-  
-
-
-
-
-To promote these packages use this command:
-
-`elastic-package promote -d=snapshot-production -n -p "aws-1.8.0"`


### PR DESCRIPTION
Execute the template even if there are no pending changes. This prevents empty notification emails.